### PR TITLE
Flush output buffers before exit.

### DIFF
--- a/scripts/nose_runner.py
+++ b/scripts/nose_runner.py
@@ -44,4 +44,7 @@ if __name__ == '__main__':
             print "There are still active threads: %s" % threads
         # We do a brute force exit here, since sys.exit will wait for
         # unjoined threads.
+        # Don't forget to flush the toilet.
+        sys.stdout.flush()
+        sys.stderr.flush()
         os._exit(error.code)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import Command, find_packages, setup
 import os
 import shutil
 
-VERSION = '0.6.0'
+VERSION = '0.6.1'
 
 
 class PublishCommand(Command):


### PR DESCRIPTION
# Problem description

When adding support for 2.7 the test exit with os._exit instead of sys.exit() and buffers are not flushed.
# Why we got into this (5 whys)

We did not check the output of tests for previous merge
# Changes description

stdout and stderr ar flushed.
# How to try and test the changes

reviewers @alibotean 

Nothing special here.
