### PR TITLE
[#1072] Revert reactor restart code.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import Command, find_packages, setup
 import os
 import shutil
 
-VERSION = '0.6.1'
+VERSION = '0.6.3'
 
 
 class PublishCommand(Command):


### PR DESCRIPTION
# Problem description

Test suite hangs on Python 2.5 when it uses this way of restarting the reactor.
# Why we got into this (5 whys)

The package was updated... but since there are no tests in the package it only failed when I tried to use with the server.
# Changes description

Reverted reactor restart to the old way.
# How to try and test the changes

reviewers @alibotean 

There is nothing much here to test.
There will be another review for the server using this new package.
