### PR TITLE
[#1219] Add Twisted compatible checks for sync deferred.

### DIFF
--- a/chevah/empirical/testcase.py
+++ b/chevah/empirical/testcase.py
@@ -408,6 +408,128 @@ class TwistedTestCase(TestCase):
         self.ignoreFailure(deferred)
         return failure
 
+    def successResultOf(self, deferred):
+        """
+        Return the current success result of C{deferred} or raise
+        C{self.failException}.
+
+        @param deferred: A L{Deferred<twisted.internet.defer.Deferred>} which
+            has a success result.  This means
+            L{Deferred.callback<twisted.internet.defer.Deferred.callback>} or
+            L{Deferred.errback<twisted.internet.defer.Deferred.errback>} has
+            been called on it and it has reached the end of its callback chain
+            and the last callback or errback returned a
+            non-L{failure.Failure}.
+        @type deferred: L{Deferred<twisted.internet.defer.Deferred>}
+
+        @raise SynchronousTestCase.failureException: If the
+            L{Deferred<twisted.internet.defer.Deferred>} has no result or has
+            a failure result.
+
+        @return: The result of C{deferred}.
+        """
+        # FIXME:1370:
+        # Remove / re-route this code after upgrading to Twisted 13.0.
+        result = []
+        deferred.addBoth(result.append)
+        if not result:
+            self.fail(
+                "Success result expected on %r, found no result instead" % (
+                    deferred,))
+        elif isinstance(result[0], Failure):
+            self.fail(
+                "Success result expected on %r, "
+                "found failure result instead:\n%s" % (
+                    deferred, result[0].getTraceback()))
+        else:
+            return result[0]
+
+    def failureResultOf(self, deferred, *expectedExceptionTypes):
+        """
+        Return the current failure result of C{deferred} or raise
+        C{self.failException}.
+
+        @param deferred: A L{Deferred<twisted.internet.defer.Deferred>} which
+            has a failure result.  This means
+            L{Deferred.callback<twisted.internet.defer.Deferred.callback>} or
+            L{Deferred.errback<twisted.internet.defer.Deferred.errback>} has
+            been called on it and it has reached the end of its callback chain
+            and the last callback or errback raised an exception or returned a
+            L{failure.Failure}.
+        @type deferred: L{Deferred<twisted.internet.defer.Deferred>}
+
+        @param expectedExceptionTypes: Exception types to expect - if
+            provided, and the the exception wrapped by the failure result is
+            not one of the types provided, then this test will fail.
+
+        @raise SynchronousTestCase.failureException: If the
+            L{Deferred<twisted.internet.defer.Deferred>} has no result, has a
+            success result, or has an unexpected failure result.
+
+        @return: The failure result of C{deferred}.
+        @rtype: L{failure.Failure}
+        """
+        # FIXME:1370:
+        # Remove / re-route this code after upgrading to Twisted 13
+        result = []
+        deferred.addBoth(result.append)
+        if not result:
+            self.fail(
+                "Failure result expected on %r, found no result instead" % (
+                    deferred,))
+        elif not isinstance(result[0], Failure):
+            self.fail(
+                "Failure result expected on %r, "
+                "found success result (%r) instead" % (deferred, result[0]))
+        elif (expectedExceptionTypes and
+              not result[0].check(*expectedExceptionTypes)):
+            expectedString = " or ".join([
+                '.'.join((t.__module__, t.__name__)) for t in
+                expectedExceptionTypes])
+
+            self.fail(
+                "Failure of type (%s) expected on %r, "
+                "found type %r instead: %s" % (
+                    expectedString, deferred, result[0].type,
+                    result[0].getTraceback()))
+        else:
+            return result[0]
+
+    def assertNoResult(self, deferred):
+        """
+        Assert that C{deferred} does not have a result at this point.
+
+        If the assertion succeeds, then the result of C{deferred} is left
+        unchanged. Otherwise, any L{failure.Failure} result is swallowed.
+
+        @param deferred: A L{Deferred<twisted.internet.defer.Deferred>}
+            without a result.  This means that neither
+            L{Deferred.callback<twisted.internet.defer.Deferred.callback>} nor
+            L{Deferred.errback<twisted.internet.defer.Deferred.errback>} has
+            been called, or that the
+            L{Deferred<twisted.internet.defer.Deferred>} is waiting on another
+            L{Deferred<twisted.internet.defer.Deferred>} for a result.
+        @type deferred: L{Deferred<twisted.internet.defer.Deferred>}
+
+        @raise SynchronousTestCase.failureException: If the
+            L{Deferred<twisted.internet.defer.Deferred>} has a result.
+        """
+        # FIXME:1370:
+        # Remove / re-route this code after upgrading to Twisted 13
+        result = []
+
+        def cb(res):
+            result.append(res)
+            return res
+        deferred.addBoth(cb)
+        if result:
+            # If there is already a failure, the self.fail below will
+            # report it, so swallow it in the deferred
+            deferred.addErrback(lambda _: None)
+            self.fail(
+                "No result expected on %r, found %r instead" % (
+                    deferred, result[0]))
+
     def getDeferredResult(self,
             deferred, timeout=1, debug=False, prevent_stop=False):
         """

--- a/chevah/empirical/tests/test_testcase.py
+++ b/chevah/empirical/tests/test_testcase.py
@@ -141,3 +141,99 @@ class TestChevahTestCase(ChevahTestCase):
 
         self.assertIsFalse(reactor._started)
         self.assertIsNone(reactor.threadpool)
+
+    def test_assertNoResult_good(self):
+        """
+        assertNoResult will not fail if deferred has no result yet.
+        """
+        deferred = defer.Deferred()
+        self.assertNoResult(deferred)
+
+    def test_assertNoResult_fail(self):
+        """
+        assertNoResult will fail if deferred has a result.
+        """
+        deferred = defer.Deferred()
+        deferred.callback(None)
+
+        with self.assertRaises(AssertionError):
+            self.assertNoResult(deferred)
+
+    def test_successResultOf_ok(self):
+        """
+        successResultOf will not fail if deferred has a result.
+        """
+        value = object()
+        deferred = defer.succeed(value)
+
+        result = self.successResultOf(deferred)
+
+        self.assertEqual(value, result)
+
+    def test_successResultOf_no_result(self):
+        """
+        successResultOf will fail if deferred has no result.
+        """
+        deferred = defer.Deferred()
+
+        with self.assertRaises(AssertionError):
+            self.successResultOf(deferred)
+
+    def test_successResultOf_failure(self):
+        """
+        successResultOf will fail if deferred has a failure.
+        """
+        deferred = defer.fail(AssertionError())
+
+        with self.assertRaises(AssertionError):
+            self.successResultOf(deferred)
+
+    def test_failureResultOf_good_any(self):
+        """
+        failureResultOf will return the failure.
+        """
+        error = AssertionError(u'bla')
+        deferred = defer.fail(error)
+
+        failure = self.failureResultOf(deferred)
+
+        self.assertEqual(error, failure.value)
+
+    def test_failureResultOf_good_type(self):
+        """
+        failureResultOf will return the failure of a specific type.
+        """
+        error = NotImplementedError(u'bla')
+        deferred = defer.fail(error)
+
+        failure = self.failureResultOf(deferred, NotImplementedError)
+
+        self.assertEqual(error, failure.value)
+
+    def test_failureResultOf_bad_type(self):
+        """
+        failureResultOf will fail if failure is not of the specified type.
+        """
+        error = NotImplementedError(u'bla')
+        deferred = defer.fail(error)
+
+        with self.assertRaises(AssertionError):
+            self.failureResultOf(deferred, SystemExit)
+
+    def test_failureResultOf_no_result(self):
+        """
+        failureResultOf will fail if deferred got no result.
+        """
+        deferred = defer.Deferred()
+
+        with self.assertRaises(AssertionError):
+            self.failureResultOf(deferred)
+
+    def test_failureResultOf_no_failure(self):
+        """
+        failureResultOf will fail if deferred is not a failure.
+        """
+        deferred = defer.succeed(None)
+
+        with self.assertRaises(AssertionError):
+            self.failureResultOf(deferred)

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -1,13 +1,20 @@
 Release notes for chevah.empirical
 ==================================
 
-0.20.1 - 21/05/2013
+0.13.0 - 21/05/2013
+-------------------
+
+* Add helpers for deferred:
+  successResultOf, failureResultOf and assertNoResult
+
+
+0.12.1 - 21/05/2013
 -------------------
 
 * Rename ChevahCommonsFactory.md5checksum to ChevahCommonsFactory.md5.
 
 
-0.20.0 - 19/05/2013
+0.12.0 - 19/05/2013
 -------------------
 
 * rename filesystem.LocalTestFilesystem,getFileContent to

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import Command, find_packages, setup
 import os
 import shutil
 
-VERSION = '0.12.1'
+VERSION = '0.13.0'
 
 
 class PublishCommand(Command):


### PR DESCRIPTION
# Problem description

Many of  the deferred that we are testing already have a result so we don't need ASync tests and we don't need to spin the reactor for getting the result.

In latest version of Twisted the following API was introduced.
http://twistedmatrix.com/documents/12.3.0/api/twisted.trial._synctest._Assertions.html

We want to use a similar API. This should improve performance and will make it much easier to reuse code between Twisted and our project.

The getDeferredResult method will only be used when working with threads and other async tests.
# Changes description

Add sync test api and test.
# How to try and test the changes

reviewers @alibotean 

Check that changes make sense.
