### PR TITLE
[#1535] Fix resolving chained deferreds.

### DIFF
--- a/chevah/empirical/testcase.py
+++ b/chevah/empirical/testcase.py
@@ -300,12 +300,11 @@ class TwistedTestCase(TestCase):
                     raise AssertionError(
                         'Deferred took more than %d to execute.' % timeout)
 
+        # Check executing all deferred from chained callbacks.
         result = deferred.result
-        if isinstance(result, Deferred):
+        while isinstance(result, Deferred):
             self._runDeferred(result, timeout=timeout, debug=debug)
             result = deferred.result
-            if isinstance(result, Deferred):
-                self._runDeferred(result, timeout=timeout, debug=debug)
 
     def executeReactor(self, timeout=1, debug=False, run_once=False):
         """

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,12 @@ Release notes for chevah.empirical
 ==================================
 
 
+0.16.2 - 20/07/2013
+-------------------
+
+* Add tests for running deferred with chained callbacks.
+
+
 0.16.1 - 18/07/2013
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import Command, find_packages, setup
 import os
 import shutil
 
-VERSION = '0.16.1'
+VERSION = '0.16.2'
 
 
 class PublishCommand(Command):


### PR DESCRIPTION
# Problem description

In case a callback from a chained deferred returns another deferred, _runDeferred does not wait for it to finish.
# Why we got into this (5 whys)
- There was no tests for this use case.
# Changes description

Run all callbacks attached to a deferred in a loop.
# How to try and test the changes

reviewers @alibotean 

Use this version in a separate project with problems. version 0.16.0 was released.

Check that code and test looks good.
