### PR TITLE
[#1737] Fix test timer for skipped tests.

### DIFF
--- a/chevah/empirical/nose_test_timer.py
+++ b/chevah/empirical/nose_test_timer.py
@@ -55,7 +55,11 @@ class TestTimer(Plugin):
 
     def _timeTaken(self, time_now, kind):
         if hasattr(self, '_timer'):
-            taken = time_now - self._timer[kind]
+            if self._timer[kind]:
+                taken = time_now - self._timer[kind]
+            else:
+                # Test was skipped and it has no timer set.
+                taken = 0.0
         else:
             # test died before it ran (probably error in setup())
             # or success/failure added before test started probably

--- a/chevah/empirical/tests/test_testcase.py
+++ b/chevah/empirical/tests/test_testcase.py
@@ -342,3 +342,35 @@ class TestEmpiricalTestCase(EmpiricalTestCase):
         mock = self.Mock(return_value=value)
 
         self.assertEqual(value, mock())
+
+    def test_skipped_test(self):
+        """
+        Just a test to check that everything works ok with skipped tests
+        in a normal testcase.
+        """
+        raise self.skipTest()
+
+
+class TestEmpiricalTestCaseSkipSetup(EmpiricalTestCase):
+    """
+    Test skipped test at setup level.
+    """
+
+    def setUp(self):
+        """
+        Skip the test, after initializing parent.
+
+        This will prevent calling of tearDown.
+        """
+        super(TestEmpiricalTestCaseSkipSetup, self).setUp()
+
+        raise self.skipTest()
+
+    def tearDown(self):
+        raise AssertionError('Should not be called.')
+
+    def test_skipped_test(self):
+        """
+        Just a test to check that everything works ok with skipped tests.
+        """
+        raise AssertionError('Should not be called')

--- a/pavement.py
+++ b/pavement.py
@@ -159,7 +159,7 @@ def build():
         pave.path.build,
         pave.getPythonLibPath(python_version=PYTHON_VERSION),
         'chevah',
-        'emprical',
+        'empirical',
         ])
     pave.fs.deleteFolder([pave.path.build, 'setup-build'])
 

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,12 @@ Release notes for chevah.empirical
 ==================================
 
 
+0.16.7 - 29/11/2013
+-------------------
+
+* Fix test timer for skipped tests.
+
+
 0.16.6 - 08/11/2013
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import Command, find_packages, setup
 import os
 import shutil
 
-VERSION = '0.16.6'
+VERSION = '0.16.7'
 
 
 class PublishCommand(Command):


### PR DESCRIPTION
# Problem description

For tests the are skipped during setup time the inner time is huge... it is in fact the current timestamp.
# Changes description

Set time to 0 for test for which inner start time was not initiated.  Ex test that were skipped during setup.
# How to try and test the changes

reviewers @alibotean 

Check that everything is on.

Run

paver test test_testcase:TestEmpiricalTestCaseSkipSetup --with-timer

the inner time (first value) should be zero.
