### PR TITLE
[#3816] Add conditional for machine using administrator privileges when running tests.

### DIFF
--- a/chevah/empirical/conditionals.py
+++ b/chevah/empirical/conditionals.py
@@ -87,9 +87,11 @@ def onCapability(name, value):
 
 def onAdminPrivileges(present):
     """
-    Run test only if administrator privileges are available on the buildslave.
+    Run test only if administrator privileges match the `present` value on
+    the machine running the tests.
 
-    For the moment only Windows 2003 and Windows XP build slaves lack this.
+    For the moment only Windows 2003 and Windows XP build slaves execute the
+    tests suite with a regular account.
     """
     hostname = gethostname()
     is_running_as_admin = 'win-2003' in hostname or 'win-xp' in hostname

--- a/chevah/empirical/conditionals.py
+++ b/chevah/empirical/conditionals.py
@@ -6,8 +6,9 @@ Decorators used for testing.
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from nose import SkipTest
 from functools import wraps
+from nose import SkipTest
+from socket import gethostname
 from unittest import TestCase
 
 from chevah.compat import process_capabilities
@@ -82,3 +83,24 @@ def onCapability(name, value):
 
     return skipOnCondition(
         check_capability, 'Capability "%s" not present.' % name)
+
+
+def onAdminPrivileges(present):
+    """
+    Run test only if administrator privileges are available on the buildslave.
+
+    For the moment only Windows 2003 and Windows XP build slaves lack this.
+    """
+    hostname = gethostname()
+    is_running_as_admin = 'win-2003' in hostname or 'win-xp' in hostname
+
+    def check_administrator():
+        if present:
+            return is_running_as_admin
+
+        return not is_running_as_admin
+
+    return skipOnCondition(
+        check_administrator,
+        'Administrator privileges not present on "%s".' % (hostname,)
+        )

--- a/chevah/empirical/tests/normal/test_mockup.py
+++ b/chevah/empirical/tests/normal/test_mockup.py
@@ -332,6 +332,8 @@ class TestFactory(EmpiricalTestCase):
         """
         value = mk.bytes(8)
 
+        self.assertEqual(len(value), 8)
+
         with self.assertRaises(UnicodeDecodeError) as context:
             value.decode()
 
@@ -365,6 +367,8 @@ class TestFactory(EmpiricalTestCase):
         """
         value = mk.bytes(16)
 
+        self.assertEqual(len(value), 16)
+
         value.decode(encoding='utf-16')
 
     def test_bytes_string_conversion_utf16_invalid(self):
@@ -373,6 +377,8 @@ class TestFactory(EmpiricalTestCase):
         is used.
         """
         value = mk.bytes(size=15)
+
+        self.assertEqual(len(value), 15)
 
         with self.assertRaises(UnicodeDecodeError) as context:
             value.decode(encoding='utf-16')

--- a/chevah/empirical/tests/normal/test_testcase.py
+++ b/chevah/empirical/tests/normal/test_testcase.py
@@ -591,6 +591,31 @@ class TestEmpiricalTestCase(EmpiricalTestCase):
         if not sys.platform.startswith('linux'):
             raise AssertionError('This should be called only on Linux.')
 
+    @conditionals.onAdminPrivileges(True)
+    def test_onAdminPrivileges_present(self):
+        """
+        Run test only on machines that execute the tests with administrator
+        privileges.
+        """
+        if 'win-2003' in self.hostname:
+            raise AssertionError(
+                'Windows 2003 BS does not run as administrator')
+        elif 'win-xp' in self.hostname:
+            raise AssertionError('Windows XP BS does not run as administrator')
+
+    @conditionals.onAdminPrivileges(False)
+    def test_onAdminPrivileges_missing(self):
+        """
+        Run test on build slaves that do not have administrator privileges.
+        """
+        if 'win-2003' in self.hostname:
+            return
+        elif 'win-xp' in self.hostname:
+            return
+
+        raise AssertionError(
+            '"%s" is running with administrator privileges' % (self.hostname,))
+
     @conditionals.onOSName(['Linux', 'aix'])
     def test_onOSName_linux_aix(self):
         """

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -2,6 +2,13 @@ Release notes for chevah.empirical
 ==================================
 
 
+0.41.0 - 23/01/2017
+-------------------
+
+* Add conditional for administrator privileges present or missing on the
+  machine running the tests.
+
+
 0.40.0 - 05/01/2017
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.39.0'
+VERSION = '0.41.0'
 
 
 class PublishCommand(Command):


### PR DESCRIPTION
Scope
=====

We want to be able to skip certain tests and testcases on machines that do not execute the testsuite with administrator privileges enabled.

For the moment only `Windows 2003` and `Windows XP` run tests as a regular user.

Changes
=======

I've used the hostname filter for lack of a better solution.

As a drive-by change I've added the assertions for byte array length.


How to try and test the changes
===============================

reviewers: @adiroiban 

Please check that changes make sense.